### PR TITLE
show which team we are each on

### DIFF
--- a/_includes/_team.html
+++ b/_includes/_team.html
@@ -12,7 +12,7 @@
           <h2 class="h5 m0">Jeff
             <small class="thin uppercase">San Francisco</small>
           </h2>
-          <h3 class="h6 m0 thin">Everything</h3>
+          <h3 class="h6 m0 thin">Administrative Overhead</h3>
           <div class="bio expandable">
             <p>Jeff likes his objects oriented in a programmable fashion and his espresso well made. If he had a time
               machine he'd stop Buddy Holly from flying on any planes ever. Hails from New York.</p>
@@ -30,7 +30,7 @@
           <h2 class="h5 m0">Jon
             <small class="thin uppercase">Pittsburgh</small>
           </h2>
-          <h3 class="h6 m0 thin">Warehouse Operations</h3>
+          <h3 class="h6 m0 thin">Warehouse &amp; Logistics</h3>
           <div class="bio expandable">
             <p>Jon is a web software engineer and pipes everything to /dev/null, the only true web scale.
               He's composed of 60% water, 20% coffee, 19% lager and 1% "other." Hails from Pittsburgh.</p>
@@ -79,7 +79,7 @@
           <h2 class="h5 m0">Dave
             <small class="thin uppercase">Washington, DC</small>
           </h2>
-          <h3 class="h6 m0 thin">Warehouse Operations</h3>
+          <h3 class="h6 m0 thin">Warehouse &amp; Logistics</h3>
           <div class="bio expandable">
             <p>Dave likes iced tea, cats, homemade bitters, and the commandline. He's written a
               <a class="link" title="Build Awesome Command-Line Applications in Ruby"


### PR DESCRIPTION
Wondering if a subtle way to indicate that we are aligned to business
problems and not e.g. products is to put our "business area" on the team
page?

![stitch_fix_technology](https://cloud.githubusercontent.com/assets/22282/4485465/0aace53a-49cc-11e4-8133-9c8dcf247b32.png)
- Anyone agree?
- Did I get the names right?
- We should do this for AA, too?

Also:
- Fix images so they are all the same height
