### PR TITLE
make Ruby 2.0 minimum supported version

### DIFF
--- a/repo-guidelines.html
+++ b/repo-guidelines.html
@@ -32,7 +32,7 @@ layout: default
             Configuration for continuous integration in <a href="http://travis-ci.org">Travis CI</a>.
           </p>
           <p>
-            Configure <code>.travis.yml</code> such that it triggers builds on all platforms in use by Stitch Fix, all <em>reasonable</em> platforms in use by the community and whatever the bleeding edge is.  For example, Ruby libraries should be built on Ruby 1.9.3 and above as well as <code>ruby-head</code>.
+            Configure <code>.travis.yml</code> such that it triggers builds on all platforms in use by Stitch Fix, all <em>reasonable</em> platforms in use by the community and whatever the bleeding edge is.  For example, Ruby libraries should be built on Ruby 2.0 and above as well as <code>ruby-head</code>.
           </p>
         </li>
         <li>


### PR DESCRIPTION
1.9.3 is no longer supported by Ruby core *and* we make heavy use of
keyword arguments, which makes 1.9.3 compatibility painful.